### PR TITLE
.cabal relax bounds

### DIFF
--- a/jak.cabal
+++ b/jak.cabal
@@ -20,10 +20,10 @@ executable jak
                      , Jak.Cursor
                      , Jak.Content
                      , Jak.Editor
-  build-depends:       base       >= 4.12.0 && < 4.13
+  build-depends:       base       <5
                      , Yampa      >= 0.13   && < 0.14
-                     , containers >= 0.06.0 && < 0.07
-                     , vty        >= 5.25.1 && < 5.26
+                     , containers >= 0.6.0 && < 0.7
+                     , vty        >= 5.25.1
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2 -threaded -Wall


### PR DESCRIPTION
- builds fine with ghc-8.8 and vty-5.28
- cabal does not allow 0 prefices before version digits